### PR TITLE
Start at page 1 not page 0

### DIFF
--- a/linkedin-employee-extract.js
+++ b/linkedin-employee-extract.js
@@ -58,7 +58,7 @@ var allTitles = [];
                     var search = "page=";
                     //Make sure page is present. allows script to run from https://www.linkedin.com/search/results/people/?facetCurrentCompany=[<id>]
                     if(url.indexOf("page=") == -1) {
-                        url = url+"&page=0";
+                        url = url+"&page=1";
                         changeIndex = url.indexOf("page=")+search.length;
                     }
                     var changeIndex = url.indexOf("page=")+search.length;


### PR DESCRIPTION
Page 1 is apparently the first page on linkedin. Starting at 0 causes the script to read the first page twice. Results where still valid since we already only printed unique entries. This fixes the extra pageload.