### PR TITLE
Add support for companies with more than 10 pages

### DIFF
--- a/linkedin-employee-extract.js
+++ b/linkedin-employee-extract.js
@@ -62,8 +62,9 @@ var allTitles = [];
                         changeIndex = url.indexOf("page=")+search.length;
                     }
                     var changeIndex = url.indexOf("page=")+search.length;
-                    var newPage = parseInt(url.substring(changeIndex, changeIndex+1)) + 1;
-                    url = url.substring(0,url.length -1) + newPage;
+                    var curPage = parseInt(url.substring(changeIndex, url.length));
+                    var newPage = curPage +1;
+                    url = url.substring(0,url.length - curPage.toString().length) + newPage;
                     if(debug) console.log("Loading url: " + url);
                     window.location.replace(url);
                 } else {


### PR DESCRIPTION
Previous version assumed that the page number was between changeindex (start of number) and changeindex+1. This was only correct for 0-9.